### PR TITLE
Use new ros3djs with CBOR PointCloud2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "ros-rviz": "EndPointCorp/polymer-ros-rviz#9c4061476657724fa8900a1ee973748e3781035d",
+    "ros-rviz": "EndPointCorp/polymer-ros-rviz#8fc0bac2f87650b7aeedf454c3887dfbb1b94aa8",
     "web-animations-js": "^2.3.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "ros-rviz": "osrf/polymer-ros-rviz#master",
+    "ros-rviz": "EndPointCorp/polymer-ros-rviz#9c4061476657724fa8900a1ee973748e3781035d",
     "web-animations-js": "^2.3.1"
   }
 }


### PR DESCRIPTION
Point to a chain of forks that results in latest roslibjs and ros3djs.  Since this chain of forks is not ideal, we should work to get all of the affected packages released and bowers updated:

* roslibjs
* ros3djs
* ros-websocket
* ros-service
* polymer-ros-rviz