### PR TITLE
Add exec_depend on python-cbor

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,5 +21,6 @@
   <exec_depend>roswww</exec_depend>
   <exec_depend>tf2_web_republisher</exec_depend>
   <exec_depend>web_video_server</exec_depend>
+  <exec_depend>python-cbor</exec_depend>
 
 </package>


### PR DESCRIPTION
rosbridge_library does not depend on this package because it is not
available on Fedora: https://github.com/RobotWebTools/rosbridge_suite/issues/375

The workaround for rosbridge_library was to include the pure Python
implementation of the cbor package in rosbridge_library.  Using the
system package with its native extensions makes encoding binary
arrays roughly twice as fast, so we install it here as a workaround
for the workaround.