### PR TITLE
Simplifying install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,11 @@ This project makes use of the following:
         cd ~/ws/src
         git clone https://github.com/osrf/rvizweb/
 
-1. You will need Node.js, here's how to install it with nvm:
+1. You will need the LTS version of Node.js. Add the PPA so that `rosdep` can fetch it:
 
-        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | bash
-        . ~/.bashrc
-        nvm install node
+        curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 
-1. Install ROS dependencies (assumes you already have ROS core):
+1. Install ROS and system dependencies (assumes you already have ROS core):
 
         cd ~/ws
         rosdep install --from-paths src --ignore-src -r -y

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,13 @@
 FROM ros:kinetic
 
-# Basic tools and dependencies
-RUN apt update && apt install -y curl && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | bash
-RUN . ~/.bashrc && nvm install node
+# Basic tools and dependencies and nodejs LTS PPA.
+RUN apt update && apt install -y curl && curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
-# Install rvizweb
+# Install rvizweb.
 WORKDIR /rvizweb_ws
 RUN git clone https://github.com/osrf/rvizweb/ src/rvizweb
 RUN rosdep install --from-paths src --ignore-src -r -y
-RUN . /opt/ros/kinetic/setup.sh && . ~/.bashrc && catkin_make install
+RUN . /opt/ros/kinetic/setup.sh && catkin_make install
 
 # Clear apt cache.
 RUN apt clean

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,8 @@ RUN apt update && apt install -y curl && curl -sL https://deb.nodesource.com/set
 
 # Install rvizweb.
 WORKDIR /rvizweb_ws
-RUN git clone https://github.com/osrf/rvizweb/ src/rvizweb
+ARG rvizweb_branch=master
+RUN git clone https://github.com/osrf/rvizweb/ src/rvizweb -b ${rvizweb_branch}
 RUN rosdep install --from-paths src --ignore-src -r -y
 RUN . /opt/ros/kinetic/setup.sh && catkin_make install
 

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
   <license>Apache 2</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="8.15">nodejs</buildtool_depend>
   <build_depend>rosbridge_server</build_depend>
   <build_depend>roswww</build_depend>
   <build_depend>tf2_web_republisher</build_depend>


### PR DESCRIPTION
See conclusions about binary release here: https://github.com/osrf/rvizweb/issues/27#issuecomment-480425186.

This PR simplifies the installation from sources. Tested in Kinetic and Melodic docker containers (some dependencies like `roswww` still need to be synced to Melodic; I'll update the Dockerfile once that's ready).