### PR TITLE
Melodic to Noetic

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -1,8 +1,8 @@
 {
   "globalOptions": {
-    "background": "#111111",
+    "background": "#ffffff",
     "colladaLoader": "collada2",
-    "fixedFrame": "/base_link"
+    "fixedFrame": "/world"
   },
   "sidebarOpened": true,
   "displays": []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,10 @@
 FROM ros:melodic
 
-# Basic tools and dependencies and nodejs LTS PPA.
-RUN apt update && apt install -y curl && curl -sL https://deb.nodesource.com/setup_8.x | bash -
-
 # Install rvizweb.
-WORKDIR /rvizweb_ws
-ARG rvizweb_branch=master
-RUN git clone https://github.com/Sausy/rvizweb.git src/rvizweb -b ${rvizweb_branch} && \
+RUN apt update && apt install -y curl && curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    mkdir /rvizweb_ws && \
+    cd /rvizweb_ws && \
+    git clone https://github.com/Sausy/rvizweb.git src/rvizweb && \
     rosdep install --from-paths src --ignore-src -r -y && \
     . /opt/ros/melodic/setup.sh && catkin_make install && \
     apt-get clean

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,17 @@
 FROM ros:kinetic
 
+
+FROM ros:melodic
+
 # Basic tools and dependencies and nodejs LTS PPA.
 RUN apt update && apt install -y curl && curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
 # Install rvizweb.
 WORKDIR /rvizweb_ws
 ARG rvizweb_branch=master
-RUN git clone https://github.com/osrf/rvizweb/ src/rvizweb -b ${rvizweb_branch}
-RUN rosdep install --from-paths src --ignore-src -r -y
-RUN . /opt/ros/kinetic/setup.sh && catkin_make install
+RUN git clone https://github.com/Sausy/rvizweb.git src/rvizweb -b ${rvizweb_branch} && \
+    rosdep install --from-paths src --ignore-src -r -y && \
+    . /opt/ros/melodic/setup.sh && catkin_make install && \
+    apt-get clean
 
-# Clear apt cache.
-RUN apt clean
-
-ENTRYPOINT ["/bin/bash", "-c", "source /rvizweb_ws/install/setup.bash && /bin/bash"]
+ENTRYPOINT ["/bin/bash", "-c", "source /rvizweb_ws/install/setup.bash && roslaunch rvizweb rvizweb.launch"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,3 @@
-FROM ros:kinetic
-
-
 FROM ros:melodic
 
 # Basic tools and dependencies and nodejs LTS PPA.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-IMAGE=rvizweb
-
 pushd "$( dirname "${BASH_SOURCE[0]}" )"
-docker build -t ${IMAGE} "$@" .
+docker build -t "sausy/rvizweb:melodic" .
 popd
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,4 +2,4 @@
 
 IMAGE=rvizweb
 
-docker run -d --privileged --rm --name "${IMAGE}" --network="host" "${IMAGE}"
+docker run -d --privileged --rm --name "sausy/rvizweb" -t "amd64" --network="host" "${IMAGE}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,4 +2,4 @@
 
 IMAGE=rvizweb
 
-docker run -d --privileged --rm --network="host" "${IMAGE}"
+docker run -d --privileged --rm --name "${IMAGE}" --network="host" "${IMAGE}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,4 +2,4 @@
 
 IMAGE=rvizweb
 
-docker run -it --privileged --rm --network="host" "${IMAGE}"
+docker run -d --privileged --rm --network="host" "${IMAGE}"

--- a/launch/rvizweb.launch
+++ b/launch/rvizweb.launch
@@ -38,9 +38,11 @@
   <param name="/rvizweb/global_config" type="str" textfile="$(arg config_file)"/>
 
   <!-- Websocket bridge -->
+  <!--
   <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
     <arg name="port" value="$(arg websocket_port)" />
   </include>
+  -->
 
   <!-- Packages server -->
   <include file="$(find roswww)/launch/roswww.launch">
@@ -49,9 +51,11 @@
   </include>
 
   <!-- TF2 republisher -->
+  <!--
   <group if="$(arg tf)">
     <node name="tf2_web_republisher" pkg="tf2_web_republisher" type="tf2_web_republisher" respawn="false" output="screen"/>
   </group>
+  -->
 
   <!-- Interactive markers -->
   <group if="$(arg interactive_markers)">


### PR DESCRIPTION
Thanks for your work. I wanted to upgrade docker image from melodic to noetic. However, facing error `curl -sL https://deb.nodesource.com/setup_8.x | bash -'` . Could you please suggested me how to build the same in noetic.
```
## Installing the NodeSource Node.js 8.x LTS Carbon repo...


## Populating apt-get cache...

+ apt-get update
Hit:1 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Hit:5 http://packages.ros.org/ros/ubuntu focal InRelease
Reading package lists...

## Confirming "focal" is supported...

+ curl -sLf -o /dev/null 'https://deb.nodesource.com/node_8.x/dists/focal/Release'

## Your distribution, identified as "focal", is not currently supported, please contact NodeSource at https://github.com/nodesource/distributions/issues if you think this is incorrect or would like your distribution to be considered for support

The command '/bin/sh -c apt update && apt install -y curl && curl -sL https://deb.nodesource.com/setup_8.x | bash -' returned a non-zero code: 1
```
